### PR TITLE
don't set initialColorModeName

### DIFF
--- a/lib/theme.js
+++ b/lib/theme.js
@@ -2,7 +2,6 @@ import base from '@hackclub/theme'
 
 const theme = base
 
-theme.initialColorModeName = 'dark'
 theme.useColorSchemeMediaQuery = false
 
 export default theme


### PR DESCRIPTION
the color theme is already set using `useColorMode()` in index.js; theme ui doesn't seem to support setting initialColorModeName.

from the server logs:
The `initialColorModeName` value should be a unique name and cannot reference a key in `theme.colors.modes`.